### PR TITLE
MEX-12: Look up vitals.xml dynamically (resubmit)

### DIFF
--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -488,7 +488,7 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
                 "mirebalais.task.vitals.label",
                 "icon-vitals",
                 "link",
-                enterSimpleHtmlFormLink("pihcore:htmlforms/vitals.xml"),
+                enterSimpleHtmlFormLink(determineHtmlFormPath(config, "vitals")),
                 Privileges.TASK_EMR_ENTER_VITALS_NOTE.privilege(),
                 and(sessionLocationHasTag(LocationTags.VITALS_LOCATION), patientHasActiveVisit())));
 
@@ -502,7 +502,7 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
                                 "editable", Boolean.TRUE,
                                 "edit-provider", "htmlformentryui",
                                 "edit-fragment", "htmlform/editHtmlFormWithSimpleUi",
-                                "definitionUiResource", "pihcore:htmlforms/vitals.xml",
+                                "definitionUiResource", determineHtmlFormPath(config, "vitals"),
                                 "returnProvider", "coreapps",
                                 "returnPage", "clinicianfacing/patient"));
 
@@ -512,7 +512,7 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
         // TODO will this be needed after we stop using the old patient visits page view, or is is replaced by encounterTypeConfig?
         registerTemplateForEncounterType(EncounterTypes.VITALS,
                 findExtensionById(EncounterTemplates.DEFAULT), "icon-vitals", null, true,
-                editSimpleHtmlFormLink("pihcore:htmlforms/vitals.xml"), null);
+                editSimpleHtmlFormLink(determineHtmlFormPath(config, "vitals")), null);
 
     }
 
@@ -822,7 +822,6 @@ public class CustomAppLoaderFactory implements AppFrameworkFactory {
                         3,
                         map("linkId", "mirebalaisreports-inpatientDailyReport-link")));
             }
-
         }
     }
 


### PR DESCRIPTION
https://tickets.pih-emr.org/browse/MEX-12

The openmrs-module-mirebalais Maven tests passed on my machine. I assume there's no module interdependence for tests, and that just running that one is sufficient. I haven't done any other verification that this doesn't break any of the other OpenMRS implementations.

This was submitted and approved as https://github.com/PIH/openmrs-module-mirebalais/pull/13, then reverted in https://github.com/PIH/openmrs-module-mirebalais/pull/14 so that it could be re-evaluated.