### PR TITLE
Make determineHtmlFormPath throw on failure to find the requested resource

### DIFF
--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderUtil.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderUtil.java
@@ -652,37 +652,31 @@ public class CustomAppLoaderUtil {
 
     static public String determineResourcePath(Config config, String providerName, String prefix, String resource) {
 
-        try {
-            // kind of ugly, and I couldn't mock it properly
-            ModuleClassLoader mcl = ModuleFactory.getModuleClassLoader(ModuleFactory.getStartedModuleById(providerName));
+        // kind of ugly, and I couldn't mock it properly
+        ModuleClassLoader mcl = ModuleFactory.getModuleClassLoader(ModuleFactory.getStartedModuleById(providerName));
 
-            // first try full path with country and site
-            String resourcePath = prefix + "/" + config.getCountry().name().toLowerCase() + "/" + config.getSite().name().toLowerCase()
-                    + "/" + resource;
+        // first try full path with country and site
+        String resourcePath = prefix + "/" + config.getCountry().name().toLowerCase() + "/" + config.getSite().name().toLowerCase()
+                + "/" + resource;
 
-            if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
-                return providerName + ":" + resourcePath;
-            }
-
-            // now try just country path
-            resourcePath = prefix + "/" + config.getCountry().name().toLowerCase() + "/" + resource;
-
-            if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
-                return providerName + ":" + resourcePath;
-            }
-
-            // now the base path
-            resourcePath = prefix + "/" + resource;
-            if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
-                return providerName + ":" + resourcePath;
-            }
-        }
-        // this catch and the return are kind of hacky, I did it this way to get the MirebalaisHospitalActivatorComponentTest to pass, but we should do this btter
-        catch (Exception e) {
-            log.error("Unable to find resource " + resource + " from provider " + providerName + " with prefix " + prefix + " - This error is expected when running tests.", e);
+        if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
+            return providerName + ":" + resourcePath;
         }
 
-        return "";
+        // now try just country path
+        resourcePath = prefix + "/" + config.getCountry().name().toLowerCase() + "/" + resource;
+
+        if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
+            return providerName + ":" + resourcePath;
+        }
+
+        // now the base path
+        resourcePath = prefix + "/" + resource;
+        if (mcl.findResource(BASE_PREFIX + resourcePath) != null) {
+            return providerName + ":" + resourcePath;
+        }
+
+        throw new IllegalStateException("Unable to find form" + resource);
     }
 
     static public Boolean containsExtension(List<Extension> extensions, String extensionId) {


### PR DESCRIPTION
The fact that it just swallows the error was what was causing the runtime errors I ran into (see [MEX-164](https://tickets.pih-emr.org/browse/MEX-164)). I made it throw instead, and ran `mvn test` from pihcore and mirebalais, and nothing seems to have broken.

I imagine @mogoodrich will want to have a look at this, especially since, surprisingly,  I didn't find the test breakage mentioned in the comments.

This depends on https://github.com/PIH/openmrs-module-pihcore/pull/20 ; please don't merge this until that one is in.