### PR TITLE
Condition to check and exclude GAD-7 from mental health program dashb…

### DIFF
--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2115,19 +2115,21 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
                 )),
                 "coreapps", "dashboardwidgets/dashboardWidget"));
 
-        apps.add(addToMentalHealthDashboardSecondColumn(app(Apps.GAD7_GRAPH,
-                "pih.app.gad7.graph.title",
-                "icon-bar-chart",
-                null,
-                null,
-                objectNode(
-                        "widget", "obsgraph",
-                        "label", "pih.app.gad7.graph.title",
-                        "icon", "icon-bar-chart",
-                        "conceptId", MirebalaisConstants.GAD7,
-                        "maxResults", "12"
-                )),
-                "coreapps", "dashboardwidgets/dashboardWidget"));
+        if (!config.getCountry().equals(ConfigDescriptor.Country.LIBERIA)) {
+            apps.add(addToMentalHealthDashboardSecondColumn(app(Apps.GAD7_GRAPH,
+                    "pih.app.gad7.graph.title",
+                    "icon-bar-chart",
+                    null,
+                    null,
+                    objectNode(
+                            "widget", "obsgraph",
+                            "label", "pih.app.gad7.graph.title",
+                            "icon", "icon-bar-chart",
+                            "conceptId", MirebalaisConstants.GAD7,
+                            "maxResults", "12"
+                    )),
+                    "coreapps", "dashboardwidgets/dashboardWidget"));
+        }
     }
 
     private void enableMalnutritionProgram() {


### PR DESCRIPTION
Condition to check and exclude GAD-7 from mental health program dashboard for Liberia - Liberia doesn't use GAD-7 on the form