### PR TITLE
UHM-3326 COVID lab result widget

### DIFF
--- a/api/src/main/java/org/openmrs/module/mirebalais/MirebalaisConstants.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/MirebalaisConstants.java
@@ -19,7 +19,7 @@ package org.openmrs.module.mirebalais;
 public class MirebalaisConstants {
 
 	public static final String MIREBALAIS_MODULE_ID = "mirebalais";
-	
+
 	public static final String RADIOLOGY_ORDERABLE_CONCEPTS_GP = "mirebalais.radiology.orderableConcepts";
 	public static final String RADIOLOGY_ORDERTYPE_GP = "radiology-order-type";
 
@@ -74,7 +74,10 @@ public class MirebalaisConstants {
     public static final String WHODAS = "163226AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     public static final String ZLDSI = "163225AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
     public static final String SEIZURE_FREQUENCY = "ba2e9e43-5a9d-423f-a33e-c34765785397";
-
+    public static final String SARS_COV2_ANTIBODY_TEST = "165853AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    public static final String SARS_COV2_ANTIGEN_TEST = "165852AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    public static final String SARS_COV2_RT_PCR_TEST = "165840AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    public static final String SARS_COV2_XPERT_TEST = "423edcfa-a5a6-4bc4-a43a-b19644252dc6";
     public static final String MED_DISPENSED_NAME_UUID = "3cd9491e-26fe-102b-80cb-0017a47871b2";
     public static final String MED_DISPENSED_FREQ_UUID = "a15c95ff-236f-488f-a879-f19fc982bbe6";
     public static final String HEART_RATE_UUID = "3ce93824-26fe-102b-80cb-0017a47871b2";

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
@@ -95,7 +95,6 @@ public class CustomAppLoaderConstants {
         public static final String ZLDSI_GRAPH = "pih.app.zldsi.graph";
         public static final String SEIZURE_FREQUENCY_GRAPH = "pih.app.seizure.frequency.graph.title";
         public static final String J9_REFERRALS = "pih.app.j9Referrals";
-        public static final String RECENT_LAB_RESULTS = "pih.app.recentLabResults";
         public static final String COVID_LAB_RESULTS = "pih.app.covidLabResults";
 
         public static final String MANAGE_ACCOUNTS = "emr.account.manageAccounts";

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
@@ -95,6 +95,7 @@ public class CustomAppLoaderConstants {
         public static final String ZLDSI_GRAPH = "pih.app.zldsi.graph";
         public static final String SEIZURE_FREQUENCY_GRAPH = "pih.app.seizure.frequency.graph.title";
         public static final String J9_REFERRALS = "pih.app.j9Referrals";
+        public static final String RECENT_LAB_RESULTS = "pih.app.recentLabResults";
 
         public static final String MANAGE_ACCOUNTS = "emr.account.manageAccounts";
         public static final String PRINTER_ADMINISTRATION = "printer.printerAdministration";

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderConstants.java
@@ -96,6 +96,7 @@ public class CustomAppLoaderConstants {
         public static final String SEIZURE_FREQUENCY_GRAPH = "pih.app.seizure.frequency.graph.title";
         public static final String J9_REFERRALS = "pih.app.j9Referrals";
         public static final String RECENT_LAB_RESULTS = "pih.app.recentLabResults";
+        public static final String COVID_LAB_RESULTS = "pih.app.covidLabResults";
 
         public static final String MANAGE_ACCOUNTS = "emr.account.manageAccounts";
         public static final String PRINTER_ADMINISTRATION = "printer.printerAdministration";
@@ -408,6 +409,7 @@ public class CustomAppLoaderConstants {
             Apps.CONDITION_LIST,
             Apps.VISITS_SUMMARY,
             Apps.HOME_VISITS_SUMMARY,
+            Apps.COVID_LAB_RESULTS,
             Apps.APPOINTMENT_SCHEDULING_HOME,
             Apps.PROVIDER_RELATIONSHIPS_CLINICAL_SUMMARY,
             Apps.RADIOLOGY_APP,

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2070,7 +2070,8 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
                 enterStandardHtmlFormLink(PihCoreUtil.getFormResource("covid19Discharge.xml")),
                 Privileges.TASK_EMR_ENTER_COVID.privilege(),
                 and(sessionLocationHasTag(LocationTags.COVID_LOCATION),
-                        visitDoesNotHaveEncounterOfType(EncounterTypes.COVID19_DISCHARGE))));
+                        visitDoesNotHaveEncounterOfType(EncounterTypes.COVID19_DISCHARGE),
+                        visitHasEncounterOfType(EncounterTypes.COVID19_INTAKE))));
     }
 
     // not currently used

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2449,19 +2449,18 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
                 Privileges.TASK_VIEW_LABS.privilege(),
                 null));
 
-        apps.add(addToClinicianDashboardFirstColumn(app(Apps.RECENT_LAB_RESULTS,
-                "mirebalais.recentLabResults.title",
-                "fas fa-fw fa-pills",
-                "dispensing/patient.page?patientId={{patient.uuid}}",
+        apps.add(addToClinicianDashboardFirstColumn(app(Apps.COVID_LAB_RESULTS,
+                "pihcore.labResults.covid",
+                "fas fa-fw fa-sun",
+                "owa/orderentry/index.html?patientId={{patient.uuid}}", // ToDo: Add link to all lab results
                 null,
                 objectNode(
-                        "widget", "obsacrossencounters",
-                        "icon", "fas fa-fw fa-pills",
-                        "label", "mirebalais.recentLabResults.title",
-                        "encounterTypes", EncounterTypes.LAB_RESULTS.uuid() + "," + EncounterTypes.COVID19_INTAKE + "," + EncounterTypes.COVID19_FOLLOWUP + "," + EncounterTypes.LAB_SPECIMEN_COLLECTION,
-                        "detailsUrl", "dispensing/dispensingSummary.page?patientId={{patient.uuid}}",
+                        "widget", "latestObsForConceptList",
+                        "icon", "fas fa-fw fa-sun",
+                        "label", "pihcore.labResults.covid",
                         "concepts", MirebalaisConstants.SARS_COV2_ANTIBODY_TEST + "," + MirebalaisConstants.SARS_COV2_ANTIGEN_TEST + "," + MirebalaisConstants.SARS_COV2_RT_PCR_TEST + "," + MirebalaisConstants.SARS_COV2_XPERT_TEST,
-                        "maxRecords", "5"  // TODO what should this be?
+                        "useConceptShortName", "true", // ToDo:  Add this configuration
+                        "maxRecords", "4"  // TODO what should this be?
                 )),
                 "coreapps", "dashboardwidgets/dashboardWidget"));
 

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2453,7 +2453,7 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
         apps.add(addToClinicianDashboardFirstColumn(app(Apps.COVID_LAB_RESULTS,
                 "pihcore.labResults.covid",
                 "fas fa-fw fa-sun",
-                "owa/orderentry/index.html?patientId={{patient.uuid}}",
+                null,
                 null,
                 objectNode(
                         "widget", "latestObsForConceptList",

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2453,15 +2453,15 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
         apps.add(addToClinicianDashboardFirstColumn(app(Apps.COVID_LAB_RESULTS,
                 "pihcore.labResults.covid",
                 "fas fa-fw fa-sun",
-                "owa/orderentry/index.html?patientId={{patient.uuid}}", // ToDo: Add link to all lab results
+                "owa/orderentry/index.html?patientId={{patient.uuid}}",
                 null,
                 objectNode(
                         "widget", "latestObsForConceptList",
                         "icon", "fas fa-fw fa-sun",
                         "label", "pihcore.labResults.covid",
                         "concepts", MirebalaisConstants.SARS_COV2_ANTIBODY_TEST + "," + MirebalaisConstants.SARS_COV2_ANTIGEN_TEST + "," + MirebalaisConstants.SARS_COV2_RT_PCR_TEST + "," + MirebalaisConstants.SARS_COV2_XPERT_TEST,
-                        "useConceptShortName", "true", // ToDo:  Add this configuration
-                        "maxRecords", "4"  // TODO what should this be?
+                        "conceptNameType", "shortName",
+                        "maxRecords", "4"
                 )),
                 "coreapps", "dashboardwidgets/dashboardWidget"));
 

--- a/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
+++ b/api/src/main/java/org/openmrs/module/mirebalais/apploader/CustomAppLoaderFactory.java
@@ -2425,6 +2425,23 @@ private String patientVisitsPageWithSpecificVisitUrl = "";
                 "owa/labworkflow/index.html?patient={{patient.uuid}}#/LabResults",
                 Privileges.TASK_VIEW_LABS.privilege(),
                 null));
+
+        apps.add(addToClinicianDashboardFirstColumn(app(Apps.RECENT_LAB_RESULTS,
+                "mirebalais.recentLabResults.title",
+                "fas fa-fw fa-pills",
+                "dispensing/patient.page?patientId={{patient.uuid}}",
+                null,
+                objectNode(
+                        "widget", "obsacrossencounters",
+                        "icon", "fas fa-fw fa-pills",
+                        "label", "mirebalais.recentLabResults.title",
+                        "encounterTypes", EncounterTypes.LAB_RESULTS.uuid() + "," + EncounterTypes.COVID19_INTAKE + "," + EncounterTypes.COVID19_FOLLOWUP + "," + EncounterTypes.LAB_SPECIMEN_COLLECTION,
+                        "detailsUrl", "dispensing/dispensingSummary.page?patientId={{patient.uuid}}",
+                        "concepts", MirebalaisConstants.SARS_COV2_ANTIBODY_TEST + "," + MirebalaisConstants.SARS_COV2_ANTIGEN_TEST + "," + MirebalaisConstants.SARS_COV2_RT_PCR_TEST + "," + MirebalaisConstants.SARS_COV2_XPERT_TEST,
+                        "maxRecords", "5"  // TODO what should this be?
+                )),
+                "coreapps", "dashboardwidgets/dashboardWidget"));
+
     }
 
     private void enableGrowthChart() {


### PR DESCRIPTION
This could be prettier with one additional attribute for the widget:

The  locale preferred concept names are shown for the concept (test name) and answers (lab result).  In this case, it would be helpful to show the short names (if available). See ticket for details:  https://pihemr.atlassian.net/browse/UHM-4671