### PR TITLE
Add site config to import map

### DIFF
--- a/distro/build-frontend.sh
+++ b/distro/build-frontend.sh
@@ -3,3 +3,5 @@ set -euo pipefail
 set +x
 npx --yes openmrs@${APP_SHELL_VERSION} build --spa-path \${SPA_PATH} --api-url \${API_URL} --target "$1"
 npx --yes openmrs@${APP_SHELL_VERSION} assemble --mode config --target "$1"
+npx --yes json-merger --pretty "$1/importmap.json" importmap-overrides.json --output "$1/importmap.json.tmp"
+mv "$1/importmap.json.tmp" "$1/importmap.json"

--- a/distro/importmap-overrides.json
+++ b/distro/importmap-overrides.json
@@ -1,0 +1,5 @@
+{
+  "imports": {
+    "config-file": "./site/config.json"
+  }
+}


### PR DESCRIPTION
The SPA application will always look for a config file at `frontend/site/config.json`. It will not load if it doesn't find it. So all of our sites must have such a file if they are using the SPA application. My plan is that `configuration/frontend` will be symlinked to `frontend/site`.